### PR TITLE
Upgrade mockito-core from 3.4.0 to 3.4.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -22,4 +22,4 @@ version.kotest=4.1.1
 
 version.kotlin=1.3.72
 
-version.org.mockito..mockito-core=3.4.0
+version.org.mockito..mockito-core=3.4.3


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.