### PR TITLE
Upgrade detekt-formatting from 1.11.0 to 1.11.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,7 +16,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.0
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.1
 
 version.kotest=4.1.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.