### PR TITLE
Upgrade kotest from 4.2.0 to 4.2.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -18,7 +18,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.1
 
-version.kotest=4.2.0
+version.kotest=4.2.2
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.