### PR TITLE
Upgrade detekt-formatting from 1.11.2 to 1.12.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,7 +17,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.2
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0
 
 version.kotest=4.2.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.