### PR TITLE
Upgrade kotest from 4.2.2 to 4.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0
 
-version.kotest=4.2.2
+version.kotest=4.2.3
 
 version.kotlin=1.4.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.