### PR TITLE
Upgrade kotlin from 1.3.72 to 1.4.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,6 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0
 
 version.kotest=4.2.2
 
-version.kotlin=1.3.72
+version.kotlin=1.4.0
 
 version.org.mockito..mockito-core=3.5.10


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.