### PR TITLE
Upgrade kotlin from 1.4.0 to 1.4.10

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,6 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.13.0
 
 version.kotest=4.2.3
 
-version.kotlin=1.4.0
+version.kotlin=1.4.10
 
 version.org.mockito..mockito-core=3.5.10


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.