### PR TITLE
Upgrade detekt-formatting from 1.13.0 to 1.13.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,7 +17,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.0
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.13.0
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.13.1
 
 version.kotest=4.2.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.