### PR TITLE
Upgrade mockito-core from 3.5.15 to 3.6.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,4 +23,4 @@ version.kotest=4.3.0
 
 version.kotlin=1.4.10
 
-version.org.mockito..mockito-core=3.5.15
+version.org.mockito..mockito-core=3.6.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.