### PR TITLE
Upgrade mockito-core from 3.6.0 to 3.6.26

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,4 +23,4 @@ version.kotest=4.3.1
 
 version.kotlin=1.4.20
 
-version.org.mockito..mockito-core=3.6.0
+version.org.mockito..mockito-core=3.6.26


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.