### PR TITLE
Upgrade kotlin from 1.4.20 to 1.4.21

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,6 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
 
 version.kotest=4.3.1
 
-version.kotlin=1.4.20
+version.kotlin=1.4.21
 
 version.org.mockito..mockito-core=3.6.28


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.