### PR TITLE
Upgrade kotlin from 1.4.21 to 1.4.30

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,6 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 
 version.kotest=4.4.0
 
-version.kotlin=1.4.21
+version.kotlin=1.4.30
 
 version.org.mockito..mockito-core=3.7.7


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.