### PR TITLE
Upgrade kotest from 4.4.1 to 4.4.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 
-version.kotest=4.4.1
+version.kotest=4.4.2
 
 version.kotlin=1.4.31
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.