### PR TITLE
Upgrade mockito-core from 3.9.0 to 3.10.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -23,4 +23,4 @@ version.kotest=4.5.0
 
 version.kotlin=1.5.0
 
-version.org.mockito..mockito-core=3.9.0
+version.org.mockito..mockito-core=3.10.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.