### PR TITLE
Upgrade detekt-formatting from 1.16.0 to 1.17.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,7 +17,7 @@ plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.16.0
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.0
 
 version.kotest=4.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.