### PR TITLE
Upgrade kotest from 4.5.0 to 4.6.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.0
 
-version.kotest=4.5.0
+version.kotest=4.6.0
 
 version.kotlin=1.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.