### PR TITLE
Upgrade kotlin from 1.5.0 to 1.5.10

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,6 +21,6 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.1
 
 version.kotest=4.6.0
 
-version.kotlin=1.5.0
+version.kotlin=1.5.10
 
 version.org.mockito..mockito-core=3.10.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.