### PR TITLE
Upgrade kotest from 4.6.0 to 4.6.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.1
 
-version.kotest=4.6.0
+version.kotest=4.6.1
 
 version.kotlin=1.5.20
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.